### PR TITLE
Make it work for macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - 37-make-it-work-for-macos
   pull_request:
     branches:
-      - main
+      - 37-make-it-work-for-macos
 
 jobs:
   setup-environment:
@@ -14,7 +14,7 @@ jobs:
     
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [macos-latest]
         cpp_version: [11, 14, 17]
 
     continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,18 @@ name: CI
 on:
   push:
     branches:
-      - 37-make-it-work-for-macos
+      - main
   pull_request:
     branches:
-      - 37-make-it-work-for-macos
+      - main
 
 jobs:
-  setup-environment:
+  build-and-test:
     runs-on: ${{ matrix.os }}
     
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest]
         cpp_version: [11, 14, 17]
 
     continue-on-error: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,11 @@ add_library(TFMC_lib STATIC ${SRC_FILES})
 target_link_libraries(TFMC_lib Boost::program_options Boost::json Boost::filesystem indicators::indicators)
 
 # Add compiler options for the library
-target_compile_options(TFMC_lib PUBLIC -O3 -mfma -mbmi2 -flto)
+if(NOT APPLE)  # Only add these flags if not on macOS
+    target_compile_options(TFMC_lib PUBLIC -O3 -mfma -mbmi2 -flto)
+else()
+    target_compile_options(TFMC_lib PUBLIC -O3 -flto)  # macOS doesn't need mfma, mbmi2
+endif()
 
 # Add executable for the main application
 add_executable(TFMC src/main.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,10 +51,6 @@ find_package(Boost REQUIRED COMPONENTS program_options json filesystem)
 #     message(FATAL_ERROR "Boost not found")
 # endif()
 
-# Ensure the GCC LTO-friendly archiver and ranlib are used
-set(CMAKE_AR "gcc-ar")
-set(CMAKE_RANLIB "gcc-ranlib")
-
 # Source files for the library
 file(GLOB SRC_FILES "src/particles.cpp" "src/observables.cpp" "src/simulation.cpp"
                     "src/utils.cpp")
@@ -67,6 +63,9 @@ target_link_libraries(TFMC_lib Boost::program_options Boost::json Boost::filesys
 
 # Add compiler options for the library
 if(NOT APPLE)  # Only add these flags if not on macOS
+    # Ensure the GCC LTO-friendly archiver and ranlib are used
+    set(CMAKE_AR "gcc-ar")
+    set(CMAKE_RANLIB "gcc-ranlib")
     target_compile_options(TFMC_lib PUBLIC -O3 -mfma -mbmi2 -flto)
 else()
     target_compile_options(TFMC_lib PUBLIC -O3 -flto)  # macOS doesn't need mfma, mbmi2

--- a/tests/test_particles.cpp
+++ b/tests/test_particles.cpp
@@ -8,26 +8,26 @@
 // configuration cfg = ReadTrimCFG(config_path);
 
 // Test the bcs function
-TEST_CASE("Test bcs function", "[test_particles][bcs]") {
+TEST_CASE("Test MinimumImageDistance function", "[test_particles][MinimumImageDistance]") {
     double epsilon = 0.01;
-    REQUIRE(bcs(0., Size/2+epsilon) == Approx(Size/2-epsilon));
-    REQUIRE(bcs(Size/2-epsilon, Size/2+epsilon) == Approx(2*epsilon));
-    REQUIRE(bcs(0., Size-epsilon) == Approx(epsilon));
+    REQUIRE(MinimumImageDistance(0., Size/2+epsilon) == Approx(Size/2-epsilon));
+    REQUIRE(MinimumImageDistance(Size/2-epsilon, Size/2+epsilon) == Approx(2*epsilon));
+    REQUIRE(MinimumImageDistance(0., Size-epsilon) == Approx(epsilon));
 }
 
 // Test the Pshift function
-TEST_CASE("Test Pshift function", "[test_particles][Pshift]") {
+TEST_CASE("Test ShiftInMainBox function", "[test_particles][ShiftInMainBox]") {
     double epsilon = 0.01;
 
     SECTION("Check Pshift at boundaries") {
-        REQUIRE(Pshift(0.0) == Approx(0.0));
-        REQUIRE(Pshift(Size) == Approx(0.0));
-        REQUIRE(Pshift(-Size) == Approx(0.0));
+        REQUIRE(ShiftInMainBox(0.0) == Approx(0.0));
+        REQUIRE(ShiftInMainBox(Size) == Approx(0.0));
+        REQUIRE(ShiftInMainBox(-Size) == Approx(0.0));
     }
 
     SECTION("Check that Pshift is periodic") {
-        REQUIRE(Pshift(Size+epsilon) == Approx(epsilon));
-        REQUIRE(Pshift(-epsilon) == Approx(Size-epsilon));
+        REQUIRE(ShiftInMainBox(Size+epsilon) == Approx(epsilon));
+        REQUIRE(ShiftInMainBox(-epsilon) == Approx(Size-epsilon));
     }
     
 }


### PR DESCRIPTION
The problem was related to gcc-ar and ranlib that are not necessary for clang.
Now builds on macos (tested on personal computer and CI workflows).
test_simulation does not pass as the random number generator used differs between macos and linux.